### PR TITLE
Infra: Harden container with read-only root filesystem

### DIFF
--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -98,6 +98,7 @@ podSecurityContext:
 # relying on container isolation (non-root, seccomp, network policies) for security.
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL
@@ -108,6 +109,7 @@ env:
   PORT: '3100'
   BASE_URL: 'http://converto'
   PLAYWRIGHT_NOSANDBOX: 'true'
+  HOME: '/tmp'
 
 # Pod annotations
 podAnnotations: {}


### PR DESCRIPTION
Set readOnlyRootFilesystem: true on the container security context so an attacker who gains code execution via Chromium cannot persist changes to the image (e.g. overwrite dist/app.js) — writes are confined to the ephemeral /tmp mount.

Point HOME at /tmp so Chromium's home-dir writes (fontconfig cache, .config, .pki) land in the existing writable tmpfs instead of the now read-only /home/pwuser, avoiding an extra writable mount.