### PR TITLE
ci: gate merges on the Docker e2e smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
-          cache: 'pnpm'
+          node-version: "24"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
-          cache: 'pnpm'
+          node-version: "24"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -66,3 +66,15 @@ jobs:
 
       - name: Integration tests
         run: pnpm test:integration
+
+  e2e:
+    name: Docker e2e smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Builds the production image and drives token → HTML → PDF against it
+      # under the hardened runtime (read-only rootfs, tmpfs /tmp, cap-drop ALL).
+      # Needs docker + bash + curl plus standard GNU userland tools (e.g. coreutils/sed/grep/base64), all present on ubuntu-latest.
+      - name: Token → HTML → PDF against the hardened image
+        run: bash tests/e2e/smoke-docker.sh


### PR DESCRIPTION
Wires the existing Docker e2e smoke test into CI as a merge gate.

## What

Adds an `e2e` job to `.github/workflows/ci.yml` that runs `tests/e2e/smoke-docker.sh`:
builds the production image and drives the full **token → HTML → PDF** path against
it under the same hardening the Helm chart applies (read-only rootfs, tmpfs `/tmp`,
`cap-drop ALL`, `no-new-privileges`, `HOME=/tmp`).

Runs on every PR and push to `main`, so a change can't merge unless the container can
still issue a token and render a real PDF end-to-end.

## Why

This is the highest-value signal for the service — it exercises exactly what ships,
including the read-only-rootfs filesystem constraints that host-run unit/integration
tests can't surface.

## Notes

- Self-contained: needs only docker + bash + curl (all on `ubuntu-latest`), no
  pnpm/node setup. The script builds its own image.
- To make it a **required** check, it must be added to branch protection on `main`
  after this merges and the check has run once (separate repo-admin step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)